### PR TITLE
Added bower packaging support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+bower_components

--- a/Readme.md
+++ b/Readme.md
@@ -8,11 +8,26 @@ or `new`, `instanceof` operators.
 
 ## Install ##
 
+### server-side ###
+
     npm install selfish
+
+### client-side ###
+
+    bower install selfish
+
 
 ## Require ##
 
+### server-side ###
+
     var Base = require('!raw.github.com/Gozala/selfish/v0.3.0/selfish').Base
+
+### client-side RequireJS ###
+
+    define(['path/to/selfish'], function(selfish) { 
+       var Base = selfish.Base;
+    }
 
 ## Examples ##
 

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,30 @@
+{
+  "name": "selfish",
+  "main": "selfish.js",
+  "version": "0.3.2",
+  "homepage": "https://github.com/Gozala/selfish",
+  "authors": [
+    "Irakli Gozalishvili <rfobic@gmail.com> (http://jeditoolkit.com)"
+  ],
+  "description": "Class-free, pure prototypal inheritance",
+  "moduleType": [
+    "amd"
+  ],
+  "keywords": [
+    "oop",
+    "inheritance",
+    "prototype",
+    "class",
+    "micro",
+    "class-free"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "devDependencies": {}
+}


### PR DESCRIPTION
Added a Bower AMD package description file (bower.json) to allow client-side install via bower package manager. Modified Readme.md to describe its usage. 

bower.json does not include dev dependencies (e.g. test) because tests were created with an npm package not available on the client-side according to my research. In any case, it is something that can be added later if needed, but it is not important for today because developers can simply install the npm locally to run the tests if they want to contribute.

Thanks for the README.md merge. Sorry I didn't read your additional word-fix request fast enough, but I'm glad you included the "objects" word fix too. It reads a lot better now.

By the way, I plan to use selfish in my knockout.js hardware configuration web project after having compared 6 libaries for clean OOP-style programming in JavaScript. I have a background in Ruby, so I liked selfish and jsclass the most, but went with selfish since its API is more unified and focuses only on OOP inheritance/mixin support. jsclass offered a lot more features than I need today. Thank you.